### PR TITLE
Fix function names + increase frequency

### DIFF
--- a/rfsocket.py
+++ b/rfsocket.py
@@ -127,8 +127,8 @@ class RFSocket:
         # bring some of the stuff as local variables, this greately
         # improves/stabilizes message signal timings
         t, one, zero, start, stop = self._timings.T, self._timings.ONE, self._timings.ZERO, self._timings.START, self._timings.STOP
-        high = self._pin.high
-        low = self._pin.low
+        high = self._pin.on
+        low = self._pin.off
         _phys = self._phys
 
         mask = 1 << 31

--- a/rfsocket.py
+++ b/rfsocket.py
@@ -72,6 +72,7 @@ class RFSocket:
     }
 
     def __init__(self, pin, chann=ANSLUT, remote_id=0, timings=RFTimings):
+        machine.freq(160000000)
         self._pin = pin
         self._chann = chann
         self._remote_id = (remote_id & (2**26 - 1)) or default_remote_id()


### PR DESCRIPTION
Hello!
The `high` and `low` functions on a `Pin` have been renamed to `on` and `off` respectively.
Also, I could not receive anything with my rtl-sdr while the frequency was 80MHz, on 160MHz it works fine; not sure if it should just be left to the user though